### PR TITLE
No requirements for process-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,6 @@
         "sidus/publishing-bundle": "dev-v1.2.x-dev",
         "sidus/file-upload-bundle": "dev-v1.2.x-dev",
         "sidus/admin-bundle": "dev-v1.2.x-dev",
-        "cleverage/process-bundle": "dev-master"
+        "cleverage/process-bundle": "*"
     }
 }


### PR DESCRIPTION
While there is no defined tags for now

 (needed to use the v1.1-dev branch)