### PR TITLE
Add JS script base_url to get an absolute path of the PNG image

### DIFF
--- a/LayoutBundle/Resources/public/js/tinymce/plugins/dataobject/plugin.js
+++ b/LayoutBundle/Resources/public/js/tinymce/plugins/dataobject/plugin.js
@@ -1,3 +1,10 @@
+var script = document.currentScript;
+var fullUrl = script.src;
+var pathArray = fullUrl.split( '/' );
+var protocol = pathArray[0];
+var host = pathArray[2];
+var currentScriptBaseUrl = protocol + '//' + host;
+
 tinymce.PluginManager.add('dataobject', function (editor) {
     var utilities = {
         isDataobject: function (node) {
@@ -8,7 +15,7 @@ tinymce.PluginManager.add('dataobject', function (editor) {
             if (this.isDataobject(node)) {
                 $(node).attr('data-object-id', dataId);
             } else {
-                editor.insertContent('<img class="dataobject" data-object-id="' + dataId + '" src="/bundles/cleverageeavmanagerlayout/img/dataobject.png" />');
+                editor.insertContent('<img class="dataobject" data-object-id="' + dataId + '" src="' + currentScriptBaseUrl + '/bundles/cleverageeavmanagerlayout/img/dataobject.png" />');
             }
         }
     };


### PR DESCRIPTION
If window page base_url is different, we need to get the absolute path.

Example :
Website : http://www.domain.com
Static assets : http://static.domain.com

When including "/bundles/cleverageeavmanagerlayout/img/dataobject.png", the real path is http://www.domain.com/.../dataobject.png.
With this PR, we will get the correct URL : http://static.domain.com/.../dataobject.png

Can be improved later if necessary ...