### PR TITLE
create UserData for user creation

### DIFF
--- a/UserBundle/Form/Type/UserType.php
+++ b/UserBundle/Form/Type/UserType.php
@@ -207,9 +207,6 @@ class UserType extends AbstractType
                 $form = $event->getForm();
                 /** @var User $user */
                 $user = $event->getData();
-                if (!$user->getId()) {
-                    return;
-                }
 
                 $dataOptions = [
                     'label' => false,
@@ -218,7 +215,7 @@ class UserType extends AbstractType
                     'family' => 'User',
                 ];
 
-                if ($user && !$user->getData()) {
+                if (!$user->getData()) {
                     $dataOptions['data'] = $this->familyRegistry->getFamily('User')->createData();
                 }
                 /** @var FormBuilderInterface $infoTab */


### PR DESCRIPTION
Currently, when we want to create a user, we don't have access to "info" tab. For me this is a bug. When we add properties to the User family and when we want to validate the User form with it, we can't do it for the creation because the user family is no created.

I fix this.